### PR TITLE
v1 performances

### DIFF
--- a/benchmark/helpers.js
+++ b/benchmark/helpers.js
@@ -28,9 +28,6 @@ function benchmark(title) {
     })
     .on('cycle', function(event){
       console.log(event.target.toString());
-    })
-    .on('complete', function(){
-      console.log(`Fastest is ${this.filter('fastest').map('name')} !`);
     });
 }
 

--- a/benchmark/mapReduce.benchmark.js
+++ b/benchmark/mapReduce.benchmark.js
@@ -16,10 +16,39 @@ const addOne = (x) => x + 1;
 const sum = (x, y) => x + y;
 
 benchmark(`map -> reduce (${data} items)`)
-  .add('alpes', wrapRunner(() =>
+  .add('alpes (map and reduce)', wrapRunner(() =>
     alpes.from(data)
       .thru(alpes.map(addOne))
       .thru(alpes.reduce(sum, 0))),
+  options)
+  .add('alpes (transduce)', wrapRunner(() =>
+    alpes.from(data)
+      .thru(alpes.transduce(
+        (reducer) => (accumulation, event) => {
+          if (event.done || event.error) {
+            return reducer(accumulation, event);
+          }
+          else {
+            return reducer(accumulation, {
+              value: addOne(event.value)
+            });
+          }
+        },
+        (accumulation, event) => {
+          if (event.done) {
+            return { accumulation, done: true };
+          }
+          else if (event.error) {
+            throw event.error;
+          }
+          else {
+            return {
+              accumulation: sum(accumulation, event.value),
+              done: false
+            };
+          }
+        },
+        () => 0))),
   options)
   .add('node streams', wrapRunner(() => new Promise((resolve, reject) => {
     const iterator = data[Symbol.iterator]();

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
   },
   "dependencies": {},
   "devDependencies": {
-    "ava": "^0.23.0",
+    "ava": "^0.25.0",
     "babel-cli": "^6.26.0",
     "babel-eslint": "^8.0.2",
     "babel-preset-flow": "^6.23.0",

--- a/src/basics.js
+++ b/src/basics.js
@@ -2,89 +2,32 @@
 const { Readable } = require('stream');
 const { StreamError } = require('./errors');
 const { wrapInPromise } = require('./utils');
+const { InternalStream, STREAM_STATUS } = require('./internalStream');
 
+import type { Event, Producer as InternalStreamProducer, Push } from './internalStream';
 import type stream from 'stream';
 
-type EventDone = {| done: true |};
-type EventError  = {| error: Error, done?: false |};
-type EventValue<T>  = {| value: T, done?: false |};
-export type Event<T> = EventDone | EventError | EventValue<T>;
-
-const STREAM_STATUS = {
-  OPEN: 'OPEN',
-  DONE: 'DONE',
-  ERROR: 'ERROR'
-};
-
-type StreamStatus = $Keys<typeof STREAM_STATUS>;
-
-export type Push<T> = (Event<T>) => boolean;
-type InternalStreamProducer<ProducedT> = (push: Push<ProducedT>, context: { status: StreamStatus }) => void;
-
-class InternalStream<T> extends Readable {
-  status: StreamStatus;
-  constructor(producer: InternalStreamProducer<T> = (push) => {}) {
-    super({
-      objectMode: true,
-      read() {
-        producer(this.pushEvent.bind(this), this);
-      }
-    });
-    this.status = STREAM_STATUS.OPEN;
-  }
-  pushEvent(event: Event<T>): boolean {
-    if (this.status != STREAM_STATUS.OPEN) {
-      // console.log('InternalStream.pushEvent push when not open', event);
-      throw new StreamError('No event should be produced once the stream has ended.');
-    }
-    else if (event.done) {
-      // console.log('InternalStream.pushEvent done');
-      this.status = STREAM_STATUS.DONE;
-      this.push(null);
-      return false;
-    }
-    else if (event.error) {
-      // console.log('InternalStream.pushEvent', event.error.toString());
-      this.status = STREAM_STATUS.ERROR;
-      // $FlowFixMe bug in the Readable type in flow, it does not support the object mode
-      this.push(event);
-      this.push(null);
-      return false;
-    }
-    else {
-      // console.log('InternalStream.pushEvent', event.value);
-      // $FlowFixMe bug in the Readable type in flow, it does not support the object mode
-      return this.push(event);
-    }
-  }
-}
-
-export type ReducerResult<T> = Promise<{| accumulation: T, done: ?boolean |}> | {| accumulation: T, done: ?boolean |}
-export type Reducer<T, AccumulationT> = (AccumulationT, Event<T>) => ReducerResult<AccumulationT>;
-
-function reduceInternalStream<T>(stream: InternalStream<T>, event: Event<T>): ReducerResult<InternalStream<T>> {
-  // Only push when the stream is open !
-  if (stream.status != STREAM_STATUS.OPEN) {
-    return { accumulation: stream, done: true };
-  }
-  else {
-    stream.pushEvent(event);
-    const done = event.done || (event.error && true);
-    return { accumulation: stream, done };
-  }
-}
-
-opaque type StreamInternals<T> = {
-  stream: Promise<stream.Readable>,
-  consumer?: any
-}
-
 export interface Stream<T> {
-  internals: StreamInternals<T>,
+  stream: Promise<InternalStream<T>>,
+  consumer?: any,
   countConsumers(): number,
   thru<R, Fn: (Stream<T>) => R>(f: Fn): R
 }
 
+function createStream<T>(stream: InternalStream<T> | Promise<InternalStream<T>>): Stream<T> {
+  return {
+    stream: stream instanceof Promise ? stream : Promise.resolve(stream),
+    countConsumers() {
+      return this.internals.consumer ? 1 : 0;
+    },
+    thru<R, Fn: (Stream<T>) => R>(f: Fn): R {
+      return f(this);
+    }
+  };
+}
+
+export type ReducerResult<T> = Promise<{| accumulation: T, done: ?boolean |}> | {| accumulation: T, done: ?boolean |}
+export type Reducer<T, AccumulationT> = (AccumulationT, Event<T>) => ReducerResult<AccumulationT>;
 export type ReducerTransformer<T, TransformedT, AccumulationT> = (Reducer<TransformedT, AccumulationT>) => Reducer<T, AccumulationT>;
 export type Seeder<AccumulationT> = () => AccumulationT;
 
@@ -178,18 +121,30 @@ function transduce<T, TransformedT, AccumulationT>(
   });
 
   return (stream) => {
-    if (stream.internals.consumer) {
+    if (stream.consumer) {
       throw new StreamError('Stream already being consumed.');
     }
-    const transducerPromise = stream.internals.stream.then(consumeStream);
-    stream.internals.consumer = transducerPromise;
+    const transducerPromise = stream.stream.then(consumeStream);
+    stream.consumer = transducerPromise;
     return transducerPromise.then(({ accumulation }) => accumulation);
   };
 }
 
+function reduceInternalStream<T>(stream: InternalStream<T>, event: Event<T>): ReducerResult<InternalStream<T>> {
+  // Only push when the stream is open !
+  if (stream.status != STREAM_STATUS.OPEN) {
+    return { accumulation: stream, done: true };
+  }
+  else {
+    stream.pushEvent(event);
+    const done = event.done || (event.error && true);
+    return { accumulation: stream, done };
+  }
+}
+
 function transduceToStream<ConsumedT, ProducedT>(transformer: ReducerTransformer<ConsumedT, ProducedT, any>): (Stream<ConsumedT>) => Stream<ProducedT> {
   const transducer = transduce(transformer, reduceInternalStream, () => new InternalStream());
-  return (stream) => wrapReadableStream(transducer(stream));
+  return (stream) => createStream(transducer(stream));
 }
 
 export type Transformer<ConsumedT, ProducedT, SeedT = void> = (event: Event<ConsumedT>, push: Push<ProducedT>, seed: ?SeedT) => ?SeedT | Promise<?SeedT>;
@@ -242,20 +197,6 @@ function subscribe<T>(subscriber: Subscriber<T>): (Stream<T>) => Promise<void> {
     () => undefined);
 }
 
-function wrapReadableStream<T>(stream: stream.Readable | Promise<stream.Readable>): Stream<T> {
-  return {
-    internals: {
-      stream: stream instanceof Promise ? stream : Promise.resolve(stream)
-    },
-    countConsumers() {
-      return this.internals.consumer ? 1 : 0;
-    },
-    thru<R, Fn: (Stream<T>) => R>(f: Fn): R {
-      return f(this);
-    }
-  };
-}
-
 export type Producer<ProducedT, SeedT> = (push: Push<ProducedT>, seed: ?SeedT) => ?SeedT | Promise<?SeedT>;
 
 function produce<ProducedT, SeedT>(producer: Producer<ProducedT, SeedT>, seed: ?SeedT): Stream<ProducedT> {
@@ -281,7 +222,7 @@ function produce<ProducedT, SeedT>(producer: Producer<ProducedT, SeedT>, seed: ?
     }
   };
 
-  return wrapReadableStream(new InternalStream(internalProducer));
+  return createStream(new InternalStream(internalProducer));
 }
 
 function fromReadable<T>(readable: stream.Readable): Stream<T> {
@@ -309,23 +250,23 @@ function fromReadable<T>(readable: stream.Readable): Stream<T> {
     .on('end', endListener)
     .resume();
 
-  return wrapReadableStream(internalStream);
+  return createStream(internalStream);
 }
 
 function fromIterable<T>(iterable: Iterable<T>): Stream<T> {
   // $FlowFixMe bug in the Iterable type of flow (cf. https://github.com/facebook/flow/issues/1163)
   const iterator: Iterator<T> = iterable[Symbol.iterator]();
-  return wrapReadableStream(new InternalStream(
-    (push) => {
+  return createStream(new InternalStream(
+    (push: Push<T>) => {
       let continueProduction = true;
       while (continueProduction) {
-        const { done, value } = iterator.next();
-        if (done) {
+        const iteratorResult = iterator.next();
+        if (iteratorResult.done) {
           push({ done: true });
           continueProduction = false;
         }
         else {
-          continueProduction = push({ value });
+          continueProduction = push({ value: iteratorResult.value });
         }
       }
     }

--- a/src/basics.js
+++ b/src/basics.js
@@ -354,5 +354,6 @@ module.exports = {
   produce,
   subscribe,
   throwError,
+  transduce,
   transform
 };

--- a/src/basics.js
+++ b/src/basics.js
@@ -10,16 +10,12 @@ import type stream from 'stream';
 export interface Stream<T> {
   stream: Promise<InternalStream<T>>,
   consumer?: any,
-  countConsumers(): number,
   thru<R, Fn: (Stream<T>) => R>(f: Fn): R
 }
 
 function createStream<T>(stream: InternalStream<T> | Promise<InternalStream<T>>): Stream<T> {
   return {
     stream: stream instanceof Promise ? stream : Promise.resolve(stream),
-    countConsumers() {
-      return this.internals.consumer ? 1 : 0;
-    },
     thru<R, Fn: (Stream<T>) => R>(f: Fn): R {
       return f(this);
     }

--- a/src/basics.js
+++ b/src/basics.js
@@ -102,7 +102,6 @@ function transduce<T, TransformedT, AccumulationT>(
           catch (error) {
             // console.log('transduce reducer sync error', error.toString());
             finish();
-            result = Promise.reject(error);
             reject(error);
           }
         }

--- a/src/basics.js
+++ b/src/basics.js
@@ -126,15 +126,9 @@ function transduce<T, TransformedT, AccumulationT>(
 }
 
 function reduceInternalStream<T>(stream: InternalStream<T>, event: Event<T>): ReducerResult<InternalStream<T>> {
-  // Only push when the stream is open !
-  if (stream.status != STREAM_STATUS.OPEN) {
-    return { accumulation: stream, done: true };
-  }
-  else {
-    stream.pushEvent(event);
-    const done = event.done || (event.error && true);
-    return { accumulation: stream, done };
-  }
+  stream.pushEvent(event);
+  const done = event.done || (event.error && true);
+  return { accumulation: stream, done };
 }
 
 function transduceToStream<ConsumedT, ProducedT>(transformer: ReducerTransformer<ConsumedT, ProducedT, any>): (Stream<ConsumedT>) => Stream<ProducedT> {

--- a/src/drain.js
+++ b/src/drain.js
@@ -4,21 +4,16 @@ const { transduce } = require('./basics');
 import type { Stream } from './basics';
 
 function drain<T>(): (Stream<T>) => Promise<void> {
-  const nothing: void = undefined;
   return transduce(
     undefined,
     (accumulation, event) => {
       if (event.error) {
         throw event.error;
       }
-      else if (event.done) {
-        return { accumulation, done: true };
-      }
-      else {
-        return { accumulation, done: false };
-      }
+
+      return { accumulation, done: event.done };
     },
-    () => nothing);
+    () => {});
 }
 
 module.exports = {

--- a/src/drain.js
+++ b/src/drain.js
@@ -1,25 +1,26 @@
 // @flow
-const { subscribe } = require('./basics');
-const { StreamError } = require('./errors');
+const { transduce } = require('./basics');
 
 import type { Stream } from './basics';
 
 function drain<T>(): (Stream<T>) => Promise<void> {
-  return (stream) => {
-    if (stream.countConsumers() > 0) {
-      throw new StreamError('Stream already being consumed.');
-    }
-    return new Promise((resolve, reject) => {
-      subscribe((event) => {
-        if (event.error) {
-          reject(event.error);
-        }
-        else if (event.done) {
-          resolve();
-        }
-      })(stream);
-    });
-  };
+  return transduce(
+    undefined,
+    (drainPromise, event) => {
+      if (drainPromise) {
+        return drainPromise;
+      }
+      else if (event.error) {
+        return Promise.reject(event.error);
+      }
+      else if (event.done) {
+        return Promise.resolve();
+      }
+      else {
+        return undefined;
+      }
+    },
+    () => undefined);
 }
 
 module.exports = {

--- a/src/drain.js
+++ b/src/drain.js
@@ -4,23 +4,21 @@ const { transduce } = require('./basics');
 import type { Stream } from './basics';
 
 function drain<T>(): (Stream<T>) => Promise<void> {
+  const nothing: void = undefined;
   return transduce(
     undefined,
-    (drainPromise, event) => {
-      if (drainPromise) {
-        return drainPromise;
-      }
-      else if (event.error) {
-        return Promise.reject(event.error);
+    (accumulation, event) => {
+      if (event.error) {
+        throw event.error;
       }
       else if (event.done) {
-        return Promise.resolve();
+        return { accumulation, done: true };
       }
       else {
-        return undefined;
+        return { accumulation, done: false };
       }
     },
-    () => undefined);
+    () => nothing);
 }
 
 module.exports = {

--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,6 @@
 // @flow
 const { drain }  = require('./drain');
-const { from, of, produce, subscribe, throwError, transform } = require('./basics');
+const { from, of, produce, subscribe, throwError, transduce, transform } = require('./basics');
 const { map }  = require('./map');
 const { reduce }  = require('./reduce');
 const { tap }  = require('./tap');
@@ -17,5 +17,6 @@ module.exports = {
   subscribe,
   tap,
   throwError,
+  transduce,
   transform
 };

--- a/src/internalStream.js
+++ b/src/internalStream.js
@@ -1,0 +1,62 @@
+// @flow
+const { Readable } = require('stream');
+const { StreamError } = require('./errors');
+
+const STREAM_STATUS = {
+  OPEN: 'OPEN',
+  DONE: 'DONE',
+  ERROR: 'ERROR'
+};
+
+export type StreamStatus = $Keys<typeof STREAM_STATUS>;
+
+type EventDone = {| done: true |};
+type EventError  = {| error: Error, done?: false |};
+type EventValue<T>  = {| value: T, done?: false |};
+export type Event<T> = EventDone | EventError | EventValue<T>;
+export type Push<T> = (Event<T>) => boolean;
+export type ProducerContext = { status: StreamStatus };
+export type Producer<T> = (push: Push<T>, context: ProducerContext) => void;
+
+class InternalStream<T> extends Readable {
+  status: StreamStatus;
+  constructor(producer: Producer<T> = () => {}) {
+    super({
+      objectMode: true,
+      read() {
+        producer(this.pushEvent.bind(this), this);
+      }
+    });
+    this.status = STREAM_STATUS.OPEN;
+  }
+  pushEvent(event: Event<T>): boolean {
+    if (this.status != STREAM_STATUS.OPEN) {
+      // console.log('InternalStream.pushEvent push when not open', event);
+      throw new StreamError('No event should be produced once the stream has ended.');
+    }
+    else if (event.done) {
+      // console.log('InternalStream.pushEvent done');
+      this.status = STREAM_STATUS.DONE;
+      this.push(null);
+      return false;
+    }
+    else if (event.error) {
+      // console.log('InternalStream.pushEvent', event.error.toString());
+      this.status = STREAM_STATUS.ERROR;
+      // $FlowFixMe bug in the Readable type in flow, it does not support the object mode
+      this.push(event);
+      this.push(null);
+      return false;
+    }
+    else {
+      // console.log('InternalStream.pushEvent', event.value);
+      // $FlowFixMe bug in the Readable type in flow, it does not support the object mode
+      return this.push(event);
+    }
+  }
+}
+
+module.exports = {
+  STREAM_STATUS,
+  InternalStream
+};

--- a/src/map.js
+++ b/src/map.js
@@ -1,22 +1,25 @@
 // @flow
-const { transform } = require('./basics');
+const { transduceToStream } = require('./basics');
 
 import type { Stream } from './basics';
 
 type Mapper<ConsumedT, ProducedT> = (value: ConsumedT) => ProducedT;
 
 function map<ConsumedT, ProducedT>(mapper: Mapper<ConsumedT, ProducedT>): (Stream<ConsumedT>) => Stream<ProducedT> {
-  return transform((event, push) => {
-    if (!event.error && !event.done) {
-      try {
-        push({ value: mapper(event.value) });
-      }
-      catch (error) {
-        push({ error });
-      }
+  return transduceToStream((reducer) => (accumulation, event) => {
+    if (event.error) {
+      return reducer(accumulation, { error: event.error });
+    }
+    else if (event.done) {
+      return reducer(accumulation, { done: true });
     }
     else {
-      push(event);
+      try {
+        return reducer(accumulation, { value: mapper(event.value) });
+      }
+      catch (error) {
+        return reducer(accumulation, { error });
+      }
     }
   });
 }

--- a/src/reduce.js
+++ b/src/reduce.js
@@ -13,10 +13,16 @@ function reduce<ConsumedT, ProducedT>(reducer: Reducer<ConsumedT, ProducedT>, se
         throw event.error;
       }
       else if (event.done) {
-        return accumulation;
+        return { accumulation, done: true };
       }
       else {
-        return reducer(accumulation, event.value);
+        const result = reducer(accumulation, event.value);
+        if (result instanceof Promise) {
+          return result.then((accumulation) => ({ accumulation, done: false }));
+        }
+        else {
+          return { accumulation: result, done: false };
+        }
       }
     },
     () => seed);

--- a/src/reduce.js
+++ b/src/reduce.js
@@ -1,42 +1,25 @@
 // @flow
-const { subscribe, transform } = require('./basics');
-const { wrapInPromise } = require('./utils');
+const { transduce } = require('./basics');
 
-import type { Stream, Transformer } from './basics';
+import type { Stream } from './basics';
 
-type ReducerP<ConsumedT, ProducedT> = (acc: ?ProducedT, value: ConsumedT) => Promise<?ProducedT>;
 type Reducer<ConsumedT, ProducedT> = (acc: ?ProducedT, value: ConsumedT) => ?ProducedT | Promise<?ProducedT>;
 
-function reduce<ConsumedT, ProducedT>(reducer: Reducer<ConsumedT, ProducedT>, initialAcc?: ProducedT): (Stream<ConsumedT>) => Promise<?ProducedT> {
-  const wrappedReducer: ReducerP<ConsumedT, ProducedT> = wrapInPromise(reducer);
-  const transformer: Transformer<ConsumedT, ?ProducedT, ProducedT> = (event, push, acc) => {
-    if (event.error) {
-      push({ error: event.error });
-    }
-    else if (event.done) {
-      push({ value: acc });
-      push({ done: true });
-    }
-    else {
-      return wrappedReducer(acc, event.value).then((newAcc) => {
-        return newAcc;
-      });
-    }
-  };
-  const transformStream = transform(transformer, initialAcc);
-
-  return (stream) => {
-    return new Promise((resolve, reject) => {
-      subscribe((event) => {
-        if (event.error) {
-          reject(event.error);
-        }
-        else if (event.value) {
-          resolve(event.value);
-        }
-      })(transformStream(stream));
-    });
-  };
+function reduce<ConsumedT, ProducedT>(reducer: Reducer<ConsumedT, ProducedT>, seed?: ProducedT): (Stream<ConsumedT>) => Promise<?ProducedT> {
+  return transduce(
+    undefined,
+    (accumulation, event) => {
+      if (event.error) {
+        throw event.error;
+      }
+      else if (event.done) {
+        return accumulation;
+      }
+      else {
+        return reducer(accumulation, event.value);
+      }
+    },
+    () => seed);
 }
 
 module.exports = {

--- a/src/tap.js
+++ b/src/tap.js
@@ -1,16 +1,16 @@
 // @flow
-const { transform } = require('./basics');
+const { transduceToStream } = require('./basics');
 
 import type { Stream } from './basics';
 
 type Tapper<T> = (value: T) => any;
 
 function tap<T>(tapper: Tapper<T>): (Stream<T>) => Stream<T> {
-  return transform((event, push) => {
+  return transduceToStream((reducer) => (accumulation, event) => {
     if (!event.error && !event.done) {
       tapper(event.value);
     }
-    push(event);
+    return reducer(accumulation, event);
   });
 }
 

--- a/test/drain.test.js
+++ b/test/drain.test.js
@@ -1,6 +1,6 @@
 // @flow
 import test from 'ava';
-import { drain, of, StreamError, tap } from '../src';
+import { drain, of, StreamError, tap, throwError } from '../src';
 
 test('Unable to drain a single stream twice', (t) => {
   const stream = of(0, 1, 2);
@@ -14,4 +14,12 @@ test('Unable to drain and tap the same stream', (t) => {
   const drainedStream1 = drain()(stream);
   t.truthy(drainedStream1);
   t.throws(() => tap(() => undefined)(stream), StreamError);
+});
+
+test('Is rejected when the stream throws an error', (t) => {
+  const ERROR_MESSAGE = 'This is a test error message';
+  return t.throws(
+    throwError(new Error(ERROR_MESSAGE)).thru(drain()),
+    ERROR_MESSAGE
+  );
 });

--- a/test/map.test.js
+++ b/test/map.test.js
@@ -1,12 +1,17 @@
 // @flow
 import test from 'ava';
-import { drain, map, of, subscribe, throwError } from '../src';
+import { drain, from, map, of, subscribe, throwError } from '../src';
 
 test('Mapped function is applied to all the value in the stream', (t) => {
   let iFrom = 0;
   let iTransformed = 0;
-  t.plan(6);
-  return of(0, 1, 2)
+  const size = 2000;
+  let data = new Array(size);
+  for (let i = 0; i < data.length; ++i) {
+    data[i] = i;
+  }
+  t.plan(size * 2);
+  return from(data)
     .thru(map((v) => {
       t.is(v, iFrom);
       ++iFrom;

--- a/test/produce.test.js
+++ b/test/produce.test.js
@@ -6,10 +6,10 @@ import { drain, produce, StreamError, tap, transform } from '../src';
 test('Finite streams can be produced', (t) => {
   const observedArray = [];
   return produce((push) => {
-    push({ value: 1 });
-    push({ value: 2 });
-    push({ value: 3 });
-    push({ done: true });
+    t.true(push({ value: 1 }));
+    t.true(push({ value: 2 }));
+    t.true(push({ value: 3 }));
+    t.false(push({ done: true }));
   })
     .thru(tap((v) => observedArray.push(v)))
     .thru(drain())
@@ -31,6 +31,37 @@ test('Pauses the production if there is a slow consumer', (t) => {
     }))
     .thru(drain())
     .then(() => t.is(observedCount, 201));
+});
+
+test('Pauses the production if there is a slow consumer (second version)', (t) => {
+  const totalCount = 500;
+  let observedCount = 0;
+  let producedCount = 0;
+  return produce((push) => {
+    for (; producedCount < totalCount ; ++producedCount) {
+      if (!push({ value: `hop #${producedCount}` })) {
+        ++producedCount;
+        return;
+      }
+    }
+    push({ done: true });
+  })
+    .thru(transform((event, push) => {
+      return delay(10).then(() => {
+        if (!event.done) {
+          observedCount++;
+          t.true(observedCount <= producedCount);
+          // Keep a maximum lag between the producer and observer
+          t.true(producedCount - observedCount < 20);
+          t.true(push(event));
+        }
+        else {
+          t.false(push(event));
+        }
+      });
+    }))
+    .thru(drain())
+    .then(() => t.is(observedCount, totalCount));
 });
 
 test('Finite streams with errors can be produced', (t) => {
@@ -128,17 +159,14 @@ test('Infinite streams and slow consumer do not override the callstack', (t) => 
   let value = 0;
   const LIMIT = 6;
   return produce((push) => {
-    // console.log('produce');
     push({ value: value++ });
   })
     .thru(transform((event, push) => {
       return new Promise((resolve) => setTimeout(() => {
         if (event.error || event.done || event.value < LIMIT) {
-          // console.log('consume');
           push(event);
         }
         else {
-          // console.log('done');
           push({ done: true });
         }
         resolve();

--- a/test/produce.test.js
+++ b/test/produce.test.js
@@ -123,22 +123,22 @@ test('Asynchronous finite streams with errors can be produced', (t) => {
     });
 });
 
-test.skip('Infinite streams and slow consumer do not override the callstack', (t) => {
+test('Infinite streams and slow consumer do not override the callstack', (t) => {
   const observedArray = [];
   let value = 0;
   const LIMIT = 6;
   return produce((push) => {
-    console.log('produce');
+    // console.log('produce');
     push({ value: value++ });
   })
     .thru(transform((event, push) => {
       return new Promise((resolve) => setTimeout(() => {
         if (event.error || event.done || event.value < LIMIT) {
-          console.log('consume');
+          // console.log('consume');
           push(event);
         }
         else {
-          console.log('done');
+          // console.log('done');
           push({ done: true });
         }
         resolve();

--- a/test/produce.test.js
+++ b/test/produce.test.js
@@ -56,7 +56,7 @@ test('Finite streams with errors can be produced (second version)', (t) => {
   const observedArray = [];
   let value = 0;
   return t.throws(
-    produce((push, next) => {
+    produce((push) => {
       push({ value: value++ });
       if (value > 4) {
         throw new Error('my cool error');
@@ -123,19 +123,22 @@ test('Asynchronous finite streams with errors can be produced', (t) => {
     });
 });
 
-test('Infinite streams and slow consumer do not override the callstack', (t) => {
+test.skip('Infinite streams and slow consumer do not override the callstack', (t) => {
   const observedArray = [];
   let value = 0;
   const LIMIT = 6;
   return produce((push) => {
+    console.log('produce');
     push({ value: value++ });
   })
     .thru(transform((event, push) => {
       return new Promise((resolve) => setTimeout(() => {
         if (event.error || event.done || event.value < LIMIT) {
+          console.log('consume');
           push(event);
         }
         else {
+          console.log('done');
           push({ done: true });
         }
         resolve();

--- a/test/reduce.test.js
+++ b/test/reduce.test.js
@@ -1,7 +1,7 @@
 // @flow
 import test from 'ava';
 import { delay } from '../src/utils';
-import { of, reduce } from '../src';
+import { of, reduce, throwError } from '../src';
 
 test('Reduce function is applied to all the value in the stream', (t) => {
   return of(0, 1, 2, 3)
@@ -21,7 +21,17 @@ test('The reduce function can retrieve a promise', (t) => {
     .then((result) => t.is(result, 6));
 });
 
-// Skipped because Ava triggers 'Unhandled Rejection' for no reason it seems
+test('The reduce function is not called on errors', (t) => {
+  return t.throws(
+    throwError(new Error('a bad error'))
+      .thru(reduce((acc, v) => t.fail('should not be called'), 0)),
+    Error
+  )
+    .then((error) => {
+      t.is(error.message, 'a bad error');
+    });
+});
+
 test('The reduce function can throw', (t) => {
   return t.throws(
     of(1, 2, 3).thru(reduce((acc, v) => {

--- a/test/reduce.test.js
+++ b/test/reduce.test.js
@@ -22,7 +22,7 @@ test('The reduce function can retrieve a promise', (t) => {
 });
 
 // Skipped because Ava triggers 'Unhandled Rejection' for no reason it seems
-test.skip('The reduce function can throw', (t) => {
+test('The reduce function can throw', (t) => {
   return t.throws(
     of(1, 2, 3).thru(reduce((acc, v) => {
       if (v == 2) {

--- a/test/reduce.test.js
+++ b/test/reduce.test.js
@@ -20,3 +20,19 @@ test('The reduce function can retrieve a promise', (t) => {
     .thru(reduce((acc, v) => delay(10).then(() => acc + v), 0))
     .then((result) => t.is(result, 6));
 });
+
+// Skipped because Ava triggers 'Unhandled Rejection' for no reason it seems
+test.skip('The reduce function can throw', (t) => {
+  return t.throws(
+    of(1, 2, 3).thru(reduce((acc, v) => {
+      if (v == 2) {
+        throw new Error('owww');
+      }
+      return acc + v;
+    }, 0)),
+    Error
+  )
+    .then((error) => {
+      t.is(error.message, 'owww');
+    });
+});

--- a/test/subscribe.test.js
+++ b/test/subscribe.test.js
@@ -9,6 +9,7 @@ test('Handles the backpressure', (t) => {
   const LIMIT = 100;
   let done = false;
   return produce((push, next) => {
+    //console.log(`${value} ->`);
     push({ value: value++ });
     if (value > LIMIT) {
       push({ done: true });
@@ -16,9 +17,10 @@ test('Handles the backpressure', (t) => {
   })
     .thru(subscribe((event) => {
       if (event.value) {
+        //console.log(`-> ${event.value}`);
         t.is(event.value, expectedValue);
         ++expectedValue;
-        return delay(50);
+        return delay(100);
       }
       else if (event.done) {
         done = true;

--- a/test/throwError.test.js
+++ b/test/throwError.test.js
@@ -4,10 +4,21 @@ import  { drain, tap, throwError } from '../src';
 
 test('Throws the given error', (t) => {
   const errorMessage = 'ahahahaha';
-  return t.throws(
-    throwError(new Error(errorMessage))
-      .thru(tap(() => t.fail('Unexpected event in the stream')))
-      .thru(drain()),
-    Error
-  ).then((error) => t.is(error.message, errorMessage));
+  return t.throws(throwError(new Error(errorMessage))
+    .thru(tap(() => t.fail('Unexpected event in the stream')))
+    .thru(drain()),
+  errorMessage);
+});
+
+test('Throws the given error properly', (t) => {
+  const errorMessage = 'huhuhuhuhuh';
+  t.plan(1);
+  try {
+    return throwError(new Error(errorMessage))
+      .thru(drain())
+      .catch((e) => t.is(e.message, errorMessage));
+  }
+  catch (e) {
+    console.log(e);
+  }
 });

--- a/test/transform.test.js
+++ b/test/transform.test.js
@@ -120,10 +120,10 @@ test('Can throw an error when done', (t) => {
     of(1, 2, 3, 4)
       .thru(transform((event, push) => {
         if (event.done) {
-          push({ error: new Error('It should never end') });
+          t.false(push({ error: new Error('It should never end') }));
         }
         else {
-          push(event);
+          t.true(push(event));
         }
       }))
       .thru(tap((v) => observed.push(v)))

--- a/yarn.lock
+++ b/yarn.lock
@@ -96,6 +96,15 @@
   dependencies:
     arrify "^1.0.1"
 
+"@ladjs/time-require@^0.1.4":
+  version "0.1.4"
+  resolved "https://registry.yarnpkg.com/@ladjs/time-require/-/time-require-0.1.4.tgz#5c615d75fd647ddd5de9cf6922649558856b21a1"
+  dependencies:
+    chalk "^0.4.0"
+    date-time "^0.1.1"
+    pretty-ms "^0.2.1"
+    text-table "^0.2.0"
+
 "@most/multicast@^1.2.5":
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/@most/multicast/-/multicast-1.3.0.tgz#e01574840df634478ac3fabd164c6e830fb3b966"
@@ -161,10 +170,6 @@ ansi-align@^2.0.0:
   resolved "https://registry.yarnpkg.com/ansi-align/-/ansi-align-2.0.0.tgz#c36aeccba563b89ceb556f3690f0b1d9e3547f7f"
   dependencies:
     string-width "^2.0.0"
-
-ansi-escapes@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/ansi-escapes/-/ansi-escapes-2.0.0.tgz#5bae52be424878dd9783e8910e3fc2922e83c81b"
 
 ansi-escapes@^3.0.0:
   version "3.0.0"
@@ -304,15 +309,16 @@ ava-init@^0.2.0:
     read-pkg-up "^2.0.0"
     write-pkg "^3.1.0"
 
-ava@^0.23.0:
-  version "0.23.0"
-  resolved "https://registry.yarnpkg.com/ava/-/ava-0.23.0.tgz#beed11730adef74a857761b62b8882bf16d5a038"
+ava@^0.25.0:
+  version "0.25.0"
+  resolved "https://registry.yarnpkg.com/ava/-/ava-0.25.0.tgz#8ac87780514f96a6fd42e1306eaa0752ce3a407f"
   dependencies:
     "@ava/babel-preset-stage-4" "^1.1.0"
     "@ava/babel-preset-transform-test-files" "^3.0.0"
     "@ava/write-file-atomic" "^2.2.0"
     "@concordance/react" "^1.0.0"
-    ansi-escapes "^2.0.0"
+    "@ladjs/time-require" "^0.1.4"
+    ansi-escapes "^3.0.0"
     ansi-styles "^3.1.0"
     arr-flatten "^1.0.1"
     array-union "^1.0.1"
@@ -321,6 +327,8 @@ ava@^0.23.0:
     auto-bind "^1.1.0"
     ava-init "^0.2.0"
     babel-core "^6.17.0"
+    babel-generator "^6.26.0"
+    babel-plugin-syntax-object-rest-spread "^6.13.0"
     bluebird "^3.0.0"
     caching-transform "^1.0.0"
     chalk "^2.0.1"
@@ -331,10 +339,10 @@ ava@^0.23.0:
     cli-spinners "^1.0.0"
     cli-truncate "^1.0.0"
     co-with-promise "^4.6.0"
-    code-excerpt "^2.1.0"
+    code-excerpt "^2.1.1"
     common-path-prefix "^1.0.0"
     concordance "^3.0.0"
-    convert-source-map "^1.2.0"
+    convert-source-map "^1.5.1"
     core-assert "^0.2.0"
     currently-unhandled "^0.4.1"
     debug "^3.0.1"
@@ -354,9 +362,8 @@ ava@^0.23.0:
     is-ci "^1.0.7"
     is-generator-fn "^1.0.0"
     is-obj "^1.0.0"
-    is-observable "^0.2.0"
+    is-observable "^1.0.0"
     is-promise "^2.1.0"
-    js-yaml "^3.8.2"
     last-line-stream "^1.0.0"
     lodash.clonedeepwith "^4.5.0"
     lodash.debounce "^4.0.3"
@@ -378,13 +385,14 @@ ava@^0.23.0:
     require-precompiled "^0.1.0"
     resolve-cwd "^2.0.0"
     safe-buffer "^5.1.1"
+    semver "^5.4.1"
     slash "^1.0.0"
-    source-map-support "^0.4.0"
+    source-map-support "^0.5.0"
     stack-utils "^1.0.1"
     strip-ansi "^4.0.0"
     strip-bom-buf "^1.0.0"
-    supports-color "^4.0.0"
-    time-require "^0.1.2"
+    supertap "^1.0.0"
+    supports-color "^5.0.0"
     trim-off-newlines "^1.0.1"
     unique-temp-dir "^1.0.0"
     update-notifier "^2.3.0"
@@ -581,6 +589,10 @@ babel-plugin-syntax-exponentiation-operator@^6.8.0:
 babel-plugin-syntax-flow@^6.18.0:
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/babel-plugin-syntax-flow/-/babel-plugin-syntax-flow-6.18.0.tgz#4c3ab20a2af26aa20cd25995c398c4eb70310c8d"
+
+babel-plugin-syntax-object-rest-spread@^6.13.0:
+  version "6.13.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-object-rest-spread/-/babel-plugin-syntax-object-rest-spread-6.13.0.tgz#fd6536f2bce13836ffa3a5458c4903a597bb3bf5"
 
 babel-plugin-syntax-trailing-function-commas@^6.20.0:
   version "6.22.0"
@@ -995,9 +1007,9 @@ co@^4.6.0:
   version "4.6.0"
   resolved "https://registry.yarnpkg.com/co/-/co-4.6.0.tgz#6ea6bdf3d853ae54ccb8e47bfa0bf3f9031fb184"
 
-code-excerpt@^2.1.0:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/code-excerpt/-/code-excerpt-2.1.0.tgz#5dcc081e88f4a7e3b554e9e35d7ef232d47f8147"
+code-excerpt@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/code-excerpt/-/code-excerpt-2.1.1.tgz#5fe3057bfbb71a5f300f659ef2cc0a47651ba77c"
   dependencies:
     convert-to-spaces "^1.0.1"
 
@@ -1076,7 +1088,7 @@ console-control-strings@^1.0.0, console-control-strings@~1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/console-control-strings/-/console-control-strings-1.1.0.tgz#3d7cf4464db6446ea644bf4b39507f9851008e8e"
 
-convert-source-map@^1.2.0, convert-source-map@^1.3.0, convert-source-map@^1.5.0:
+convert-source-map@^1.3.0, convert-source-map@^1.5.0, convert-source-map@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/convert-source-map/-/convert-source-map-1.5.1.tgz#b8278097b9bc229365de5c62cf5fcaed8b5599e5"
 
@@ -1739,6 +1751,10 @@ has-flag@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-2.0.0.tgz#e8207af1cc7b30d446cc70b734b5e8be18f88d51"
 
+has-flag@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
+
 has-unicode@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/has-unicode/-/has-unicode-2.0.1.tgz#e0e6fe6a28cf51138855e086d1691e771de2a8b9"
@@ -1837,7 +1853,7 @@ indent-string@^2.1.0:
   dependencies:
     repeating "^2.0.0"
 
-indent-string@^3.0.0, indent-string@^3.1.0:
+indent-string@^3.0.0, indent-string@^3.1.0, indent-string@^3.2.0:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.2.0.tgz#4a5fd6d27cc332f37e5419a504dbb837105c9289"
 
@@ -1996,6 +2012,12 @@ is-observable@^0.2.0:
   dependencies:
     symbol-observable "^0.2.2"
 
+is-observable@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/is-observable/-/is-observable-1.1.0.tgz#b3e986c8f44de950867cab5403f5a3465005975e"
+  dependencies:
+    symbol-observable "^1.1.0"
+
 is-path-cwd@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-path-cwd/-/is-path-cwd-1.0.0.tgz#d225ec23132e89edd38fda767472e62e65f1106d"
@@ -2131,7 +2153,7 @@ js-tokens@^3.0.0, js-tokens@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/js-tokens/-/js-tokens-3.0.2.tgz#9866df395102130e38f7f996bceb65443209c25b"
 
-js-yaml@^3.8.2, js-yaml@^3.9.1:
+js-yaml@^3.10.0, js-yaml@^3.9.1:
   version "3.10.0"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.10.0.tgz#2e78441646bd4682e963f22b6e92823c309c62dc"
   dependencies:
@@ -3119,6 +3141,14 @@ semver-diff@^2.0.0:
   version "5.4.1"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.4.1.tgz#e059c09d8571f0540823733433505d3a2f00b18e"
 
+semver@^5.4.1:
+  version "5.5.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.5.0.tgz#dc4bbc7a6ca9d916dee5d43516f0092b58f7b8ab"
+
+serialize-error@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/serialize-error/-/serialize-error-2.1.0.tgz#50b679d5635cdf84667bdc8e59af4e5b81d5f60a"
+
 set-blocking@^2.0.0, set-blocking@~2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/set-blocking/-/set-blocking-2.0.0.tgz#045f9782d011ae9a6803ddd382b24392b3d890f7"
@@ -3167,11 +3197,17 @@ sort-keys@^2.0.0:
   dependencies:
     is-plain-obj "^1.0.0"
 
-source-map-support@^0.4.0, source-map-support@^0.4.15:
+source-map-support@^0.4.15:
   version "0.4.18"
   resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.4.18.tgz#0286a6de8be42641338594e97ccea75f0a2c585f"
   dependencies:
     source-map "^0.5.6"
+
+source-map-support@^0.5.0:
+  version "0.5.3"
+  resolved "https://registry.yarnpkg.com/source-map-support/-/source-map-support-0.5.3.tgz#2b3d5fff298cfa4d1afd7d4352d569e9a0158e76"
+  dependencies:
+    source-map "^0.6.0"
 
 source-map@^0.4.4:
   version "0.4.4"
@@ -3182,6 +3218,10 @@ source-map@^0.4.4:
 source-map@^0.5.0, source-map@^0.5.3, source-map@^0.5.6, source-map@~0.5.1:
   version "0.5.7"
   resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.5.7.tgz#8a039d2d1021d22d1ea14c80d8ea468ba2ef3fcc"
+
+source-map@^0.6.0:
+  version "0.6.1"
+  resolved "https://registry.yarnpkg.com/source-map/-/source-map-0.6.1.tgz#74722af32e9614e9c287a8d0bbde48b5e2f1a263"
 
 spawn-wrap@=1.3.8:
   version "1.3.8"
@@ -3301,6 +3341,16 @@ strip-json-comments@~2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/strip-json-comments/-/strip-json-comments-2.0.1.tgz#3c531942e908c2697c0ec344858c286c7ca0a60a"
 
+supertap@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/supertap/-/supertap-1.0.0.tgz#bd9751c7fafd68c68cf8222a29892206a119fa9e"
+  dependencies:
+    arrify "^1.0.1"
+    indent-string "^3.2.0"
+    js-yaml "^3.10.0"
+    serialize-error "^2.1.0"
+    strip-ansi "^4.0.0"
+
 supports-color@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
@@ -3317,6 +3367,12 @@ supports-color@^4.0.0:
   dependencies:
     has-flag "^2.0.0"
 
+supports-color@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.2.0.tgz#b0d5333b1184dd3666cbe5aa0b45c5ac7ac17a4a"
+  dependencies:
+    has-flag "^3.0.0"
+
 symbol-observable@^0.2.2:
   version "0.2.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-0.2.4.tgz#95a83db26186d6af7e7a18dbd9760a2f86d08f40"
@@ -3328,6 +3384,10 @@ symbol-observable@^1.0.2:
 symbol-observable@^1.0.4:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.0.4.tgz#29bf615d4aa7121bdd898b22d4b3f9bc4e2aa03d"
+
+symbol-observable@^1.1.0:
+  version "1.2.0"
+  resolved "https://registry.yarnpkg.com/symbol-observable/-/symbol-observable-1.2.0.tgz#c22688aed4eab3cdc2dfeacbb561660560a00804"
 
 table@^4.0.1:
   version "4.0.2"
@@ -3391,15 +3451,6 @@ through2@^2.0.0:
 through@^2.3.6:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
-
-time-require@^0.1.2:
-  version "0.1.2"
-  resolved "https://registry.yarnpkg.com/time-require/-/time-require-0.1.2.tgz#f9e12cb370fc2605e11404582ba54ef5ca2b2d98"
-  dependencies:
-    chalk "^0.4.0"
-    date-time "^0.1.1"
-    pretty-ms "^0.2.1"
-    text-table "^0.2.0"
 
 time-zone@^1.0.0:
   version "1.0.0"


### PR DESCRIPTION
Objective: getting performances on par with Node.JS stream.
---
_On f638064_ (introduction of the tests, before the work on this PR)

```console
$ NODE_ENV=production node ./benchmark/mapReduce.benchmark.js
alpes x 6.95 ops/sec ±3.36% (37 runs sampled)
node streams x 102 ops/sec ±1.74% (76 runs sampled)
highland x 471 ops/sec ±1.69% (79 runs sampled)
most x 23,633 ops/sec ±0.84% (82 runs sampled)
$ NODE_ENV=production node ./benchmark/drain.benchmark.js
alpes x 27.71 ops/sec ±4.40% (65 runs sampled)
node streams x 266 ops/sec ±4.18% (78 runs sampled)
highland x 4,374 ops/sec ±5.03% (64 runs sampled)
most x 47,610 ops/sec ±1.63% (79 runs sampled)
```

_On 133040c_ (after the work on this PR)

```console
$ NODE_ENV=production node ./benchmark/mapReduce.benchmark.js
alpes (map and reduce) x 72.02 ops/sec ±1.68% (79 runs sampled)
alpes (transduce) x 109 ops/sec ±3.67% (70 runs sampled)
node streams x 108 ops/sec ±1.78% (80 runs sampled)
highland x 517 ops/sec ±2.09% (82 runs sampled)
most x 14,833 ops/sec ±1.37% (80 runs sampled)
$ NODE_ENV=production node ./benchmark/drain.benchmark.js
alpes x 130 ops/sec ±1.03% (77 runs sampled)
node streams x 267 ops/sec ±1.44% (78 runs sampled)
highland x 4,263 ops/sec ±6.44% (55 runs sampled)
most x 48,291 ops/sec ±0.65% (80 runs sampled)
```

**Between x5 and x10 in terms on raw performances**
