### PR TITLE
Reimplement streams using ideas from 'pull-stream'

### DIFF
--- a/src/event.js
+++ b/src/event.js
@@ -1,0 +1,22 @@
+// @flow
+type EventDone = {| done: true |};
+type EventError  = {| error: Error, done?: false |};
+type EventValue<T>  = {| value: T, done?: false |};
+export type Event<T> = EventDone | EventError | EventValue<T>;
+
+function strFromEvent<T>(event: Event<T>): string {
+  if (event.error) {
+    return `<Error='${event.error.message}'>`;
+  }
+  else if (event.done) {
+    return '<Done>';
+  }
+  else {
+    // $FlowFixMe
+    return `<Value=${event.value}>`;
+  }
+}
+
+module.exports = {
+  strFromEvent
+};

--- a/src/index.js
+++ b/src/index.js
@@ -1,9 +1,11 @@
 // @flow
 const { drain }  = require('./drain');
-const { from, of, produce, subscribe, throwError, transduce, transform } = require('./basics');
+const { from, of, produce, throwError, transduce } = require('./basics');
 const { map }  = require('./map');
 const { reduce }  = require('./reduce');
+const { subscribe }  = require('./subscribe');
 const { tap }  = require('./tap');
+const { transform }  = require('./transform');
 const { StreamError } = require('./errors');
 
 module.exports = {

--- a/src/internalStream.js
+++ b/src/internalStream.js
@@ -17,19 +17,101 @@ export type Event<T> = EventDone | EventError | EventValue<T>;
 export type Push<T> = (Event<T>) => boolean;
 export type ProducerContext = { status: StreamStatus };
 export type Producer<T> = (push: Push<T>, context: ProducerContext) => void;
+export type ConsumerReducer = Promise<boolean> | boolean;
+export type Consumer<T> = (Event<T>) => ConsumerReducer;
 
-class InternalStream<T> extends Readable {
+class InternalStream<T> {
   status: StreamStatus;
+  readable: Readable;
   constructor(producer: Producer<T> = () => {}) {
-    super({
+    const self = this;
+    this.readable = new Readable({
       objectMode: true,
       read() {
-        producer(this.pushEvent.bind(this), this);
+        producer(self.push.bind(self), self);
       }
     });
     this.status = STREAM_STATUS.OPEN;
   }
-  pushEvent(event: Event<T>): boolean {
+  consume(consumer: Consumer<T>): Promise<void> {
+    return new Promise((resolve, reject) => {
+      let done: ConsumerReducer = false;
+
+      const start = () => {
+        this.readable
+          .on('data', onData)
+          .on('end', onEnd)
+          .resume();
+      };
+      const finish = () => {
+        this.readable
+          .pause()
+          .removeListener('data', onData)
+          .removeListener('end', onEnd);
+      };
+      const onData = (event) => {
+        if (event.error) {
+          // console.log('stream listener error', event.error.toString());
+          finish();
+
+          done = Promise.resolve(done)
+            .then(() => consumer(event));
+          done.then(() => resolve(), reject);
+        }
+        else if (done instanceof Promise) {
+          // console.log('stream listener value (Promise)', event.value);
+
+          // -> Pause until the previous consume is done
+          this.readable.pause();
+          done = done
+            .then((done) => {
+              if (!done) {
+                this.readable.resume();
+                return consumer(event);
+              }
+              return done;
+            });
+          done
+            .then((done) => {
+              if (done) {
+                finish();
+                resolve();
+              }
+            })
+            .catch((error) => {
+              finish();
+              reject(error);
+            });
+        }
+        else if (!done) {
+          // console.log('stream listener value (Sync)', event.value);
+          try {
+            done = consumer(event);
+            if (!(done instanceof Promise) && done) {
+              finish();
+              resolve();
+            }
+          }
+          catch (error) {
+            finish();
+            reject(error);
+          }
+        }
+      };
+
+      const onEnd = () => {
+        // console.log('stream listener end');
+        finish();
+
+        done = Promise.resolve(done)
+          .then(() => consumer({ done: true }));
+        done.then(() => resolve(), reject);
+      };
+
+      start();
+    });
+  }
+  push(event: Event<T>): boolean {
     if (this.status != STREAM_STATUS.OPEN) {
       // console.log('InternalStream.pushEvent push when not open', event);
       throw new StreamError('No event should be produced once the stream has ended.');
@@ -37,21 +119,21 @@ class InternalStream<T> extends Readable {
     else if (event.done) {
       // console.log('InternalStream.pushEvent done');
       this.status = STREAM_STATUS.DONE;
-      this.push(null);
+      this.readable.push(null);
       return false;
     }
     else if (event.error) {
       // console.log('InternalStream.pushEvent', event.error.toString());
       this.status = STREAM_STATUS.ERROR;
       // $FlowFixMe bug in the Readable type in flow, it does not support the object mode
-      this.push(event);
-      this.push(null);
+      this.readable.push(event);
+      this.readable.push(null);
       return false;
     }
     else {
       // console.log('InternalStream.pushEvent', event.value);
       // $FlowFixMe bug in the Readable type in flow, it does not support the object mode
-      return this.push(event);
+      return this.readable.push(event);
     }
   }
 }

--- a/src/internalStream.js
+++ b/src/internalStream.js
@@ -1,24 +1,9 @@
 // @flow
 const EventEmitter = require('events');
 const { StreamError } = require('./errors');
+// const { strFromEvent } = require('./event');
 
-type EventDone = {| done: true |};
-type EventError  = {| error: Error, done?: false |};
-type EventValue<T>  = {| value: T, done?: false |};
-export type Event<T> = EventDone | EventError | EventValue<T>;
-
-function strFromEvent<T>(event: Event<T>): string {
-  if (event.error) {
-    return `<Error='${event.error.message}'>`;
-  }
-  else if (event.done) {
-    return '<Done>';
-  }
-  else {
-    // $FlowFixMe
-    return `<Value=${event.value}>`;
-  }
-}
+import type { Event } from './event';
 
 export type Push<T> = (Event<T>) => boolean;
 
@@ -224,6 +209,5 @@ class InternalStream<T> extends EventEmitter {
 }
 
 module.exports = {
-  InternalStream,
-  strFromEvent
+  InternalStream
 };

--- a/src/internalStream.js
+++ b/src/internalStream.js
@@ -1,144 +1,229 @@
 // @flow
-const { Readable } = require('stream');
+const EventEmitter = require('events');
 const { StreamError } = require('./errors');
-
-const STREAM_STATUS = {
-  OPEN: 'OPEN',
-  DONE: 'DONE',
-  ERROR: 'ERROR'
-};
-
-export type StreamStatus = $Keys<typeof STREAM_STATUS>;
 
 type EventDone = {| done: true |};
 type EventError  = {| error: Error, done?: false |};
 type EventValue<T>  = {| value: T, done?: false |};
 export type Event<T> = EventDone | EventError | EventValue<T>;
+
+function strFromEvent<T>(event: Event<T>): string {
+  if (event.error) {
+    return `<Error='${event.error.message}'>`;
+  }
+  else if (event.done) {
+    return '<Done>';
+  }
+  else {
+    // $FlowFixMe
+    return `<Value=${event.value}>`;
+  }
+}
+
 export type Push<T> = (Event<T>) => boolean;
-export type ProducerContext = { status: StreamStatus };
-export type Producer<T> = (push: Push<T>, context: ProducerContext) => void;
-export type ConsumerReducer = Promise<boolean> | boolean;
-export type Consumer<T> = (Event<T>) => ConsumerReducer;
 
-class InternalStream<T> {
-  status: StreamStatus;
-  readable: Readable;
-  constructor(producer: Producer<T> = () => {}) {
-    const self = this;
-    this.readable = new Readable({
-      objectMode: true,
-      read() {
-        producer(self.push.bind(self), self);
+const PRODUCER_STATUS = {
+  ONGOING: 'ONGOING',
+  DONE: 'DONE',
+  ERROR: 'ERROR'
+};
+type ProducerStatus = $Keys<typeof PRODUCER_STATUS>;
+export type Producer<T> = (push: Push<T>, stop?: boolean) => Promise<void> | void;
+
+const CONSUMER_STATUS = {
+  NONE: 'NONE',
+  BUSY: 'BUSY',
+  READY: 'READY',
+  DONE: 'DONE'
+};
+type ConsumerStatus = $Keys<typeof CONSUMER_STATUS>;
+export type Consumer<T> = (Event<T>) => Promise<boolean> | boolean;
+
+export type InternalStreamConfiguration = {|
+  bufferHighWaterMark: number
+|}
+
+const DEFAULT_INTERNAL_STREAM_CONFIGURATION : InternalStreamConfiguration = {
+  bufferHighWaterMark: 100
+};
+
+class InternalStream<T> extends EventEmitter {
+  cfg: InternalStreamConfiguration;
+
+  producer: ?Producer<T>;
+  producerStatus: ProducerStatus;
+  buffer: Event<T>[];
+
+  consumer: ?Consumer<T>;
+  consumerStatus: ConsumerStatus;
+
+  constructor(producer: ?Producer<T>, cfg: InternalStreamConfiguration = DEFAULT_INTERNAL_STREAM_CONFIGURATION) {
+    super();
+    this.producerStatus = PRODUCER_STATUS.ONGOING;
+    this.producer = producer;
+    this.buffer = [];
+    this.cfg = cfg;
+
+    this.consumerStatus = CONSUMER_STATUS.NONE;
+    this.consumer = null;
+
+    // this.on('consumerDone', (error) => error ? console.log('**** error', error) : console.log('**** done'));
+    // this.on('consumerReady', () => console.log('**** ready'));
+  }
+  _handleConsumerError(error: Error) {
+    this.consumerStatus = CONSUMER_STATUS.DONE;
+    this.emit('consumerDone', error);
+  }
+  _handleConsumerAsyncResult(done: boolean) {
+    if (done) {
+      this.consumerStatus = CONSUMER_STATUS.DONE;
+      this.emit('consumerDone');
+    }
+    else {
+      this.consumerStatus = CONSUMER_STATUS.READY;
+      this.emit('consumerReady');
+    }
+  }
+  _handleConsumerSyncResult(done: boolean) {
+    if (done) {
+      this.consumerStatus = CONSUMER_STATUS.DONE;
+      this.emit('consumerDone');
+    }
+    else {
+      this.consumerStatus = CONSUMER_STATUS.READY;
+    }
+  }
+  _consume(event: Event<T>) {
+    //console.log('InternalStream._consume', strFromEvent(event), this.consumerStatus);
+    // By construction we're sure that
+    //  - `this.consumerStatus == CONSUMER_STATUS.READY`
+    // if (this.consumerStatus != CONSUMER_STATUS.READY) {
+    //   throw new Error('_consume should not be called if the consumer is not ready.');
+    // }
+    //  - this.consumer is defined
+    // if (this.consumer == null) {
+    //   throw new Error('this.consumerStatus should not be \'READY\' if no consumer is defined.');
+    // }
+    // $FlowFixMe
+    const consumer: Consumer<T> = this.consumer;
+    try {
+      const consumerDone = consumer(event);
+      if (consumerDone instanceof Promise) {
+        this.consumerStatus = CONSUMER_STATUS.BUSY;
+        // console.log('**** busy');
+        consumerDone
+          .then(this._handleConsumerAsyncResult.bind(this))
+          .catch(this._handleConsumerError.bind(this));
       }
-    });
-    this.status = STREAM_STATUS.OPEN;
+      else {
+        this._handleConsumerSyncResult(consumerDone);
+      }
+    }
+    catch (error) {
+      this._handleConsumerError(error);
+    }
   }
-  consume(consumer: Consumer<T>): Promise<void> {
-    return new Promise((resolve, reject) => {
-      let done: ConsumerReducer = false;
-
-      const start = () => {
-        this.readable
-          .on('data', onData)
-          .on('end', onEnd)
-          .resume();
-      };
-      const finish = () => {
-        this.readable
-          .pause()
-          .removeListener('data', onData)
-          .removeListener('end', onEnd);
-      };
-      const onData = (event) => {
-        if (event.error) {
-          // console.log('stream listener error', event.error.toString());
-          finish();
-
-          done = Promise.resolve(done)
-            .then(() => consumer(event));
-          done.then(() => resolve(), reject);
-        }
-        else if (done instanceof Promise) {
-          // console.log('stream listener value (Promise)', event.value);
-
-          // -> Pause until the previous consume is done
-          this.readable.pause();
-          done = done
-            .then((done) => {
-              if (!done) {
-                this.readable.resume();
-                return consumer(event);
-              }
-              return done;
-            });
-          done
-            .then((done) => {
-              if (done) {
-                finish();
-                resolve();
-              }
-            })
-            .catch((error) => {
-              finish();
-              reject(error);
-            });
-        }
-        else if (!done) {
-          // console.log('stream listener value (Sync)', event.value);
-          try {
-            done = consumer(event);
-            if (!(done instanceof Promise) && done) {
-              finish();
-              resolve();
-            }
-          }
-          catch (error) {
-            finish();
-            reject(error);
-          }
-        }
-      };
-
-      const onEnd = () => {
-        // console.log('stream listener end');
-        finish();
-
-        done = Promise.resolve(done)
-          .then(() => consumer({ done: true }));
-        done.then(() => resolve(), reject);
-      };
-
-      start();
-    });
-  }
-  push(event: Event<T>): boolean {
-    if (this.status != STREAM_STATUS.OPEN) {
-      // console.log('InternalStream.pushEvent push when not open', event);
+  _produce(event: Event<T>): boolean {
+    //console.log('InternalStream._produce', strFromEvent(event));
+    let productionDone = false;
+    if (this.producerStatus != PRODUCER_STATUS.ONGOING) {
       throw new StreamError('No event should be produced once the stream has ended.');
     }
     else if (event.done) {
-      // console.log('InternalStream.pushEvent done');
-      this.status = STREAM_STATUS.DONE;
-      this.readable.push(null);
-      return false;
+      this.producerStatus = PRODUCER_STATUS.DONE;
+      productionDone = true;
     }
     else if (event.error) {
-      // console.log('InternalStream.pushEvent', event.error.toString());
-      this.status = STREAM_STATUS.ERROR;
-      // $FlowFixMe bug in the Readable type in flow, it does not support the object mode
-      this.readable.push(event);
-      this.readable.push(null);
-      return false;
+      this.producerStatus = PRODUCER_STATUS.ERROR;
+      productionDone = true;
     }
-    else {
-      // console.log('InternalStream.pushEvent', event.value);
-      // $FlowFixMe bug in the Readable type in flow, it does not support the object mode
-      return this.readable.push(event);
+
+    switch (this.consumerStatus) {
+      case CONSUMER_STATUS.NONE:
+      case CONSUMER_STATUS.BUSY:
+      {
+        // No consumer or busy consumer, let's buffer the event
+        this.buffer.push(event);
+        return !productionDone && this.buffer.length < this.cfg.bufferHighWaterMark;
+      }
+      case CONSUMER_STATUS.DONE:
+      {
+        // The consumer is done, let's just stop guys!
+        return false;
+      }
+      default:
+      {
+        this._consume(event);
+        return !productionDone;
+      }
+    }
+  }
+  _doConsume() {
+    //console.log('InternalStream._doConsume', this.consumerStatus, this.buffer.length);
+
+    // 1 - let's evacuate what is in the buffer
+    while (
+      this.buffer.length > 0 &&
+      this.consumerStatus == CONSUMER_STATUS.READY
+    ) {
+      const event : Event<T> = this.buffer.shift();
+      this._consume(event);
+    }
+    // 2 - nothing in the buffer, let's produce!
+    if (this.producer != null) {
+      const producer = this.producer;
+      while (
+        this.producerStatus == PRODUCER_STATUS.ONGOING &&
+        this.consumerStatus != CONSUMER_STATUS.BUSY
+      ) {
+        const consumerDone = this.consumerStatus == CONSUMER_STATUS.DONE;
+        const producerResult = producer(this._produce.bind(this), consumerDone);
+        if (producerResult instanceof Promise) {
+          producerResult.then(this._doConsume.bind(this));
+          break;
+        }
+        if (consumerDone) {
+          break;
+        }
+      }
+    }
+
+    if (this.consumerStatus == CONSUMER_STATUS.BUSY) {
+      this.once('consumerReady', this._doConsume.bind(this));
+    }
+  }
+  consume(consumer: Consumer<T>): Promise<void> {
+    // console.log('InternalStream.consume');
+    if (this.consumer != null) {
+      throw new StreamError('Stream already being consumed.');
+    }
+    this.consumer = consumer;
+    this.consumerStatus = CONSUMER_STATUS.READY;
+    return new Promise((resolve, reject) => {
+      this.once('consumerDone', (error) => {
+        if (error) {
+          reject(error);
+        }
+        else {
+          resolve();
+        }
+      });
+      this._doConsume();
+    });
+  }
+  waitAndPush(event: Event<T>): Promise<boolean> | boolean {
+    // console.log('InternalStream.waitAndPush', strFromEvent(event), this.consumerStatus);
+    switch (this.consumerStatus) {
+      case CONSUMER_STATUS.BUSY:
+        return new Promise(this.once.bind(this, 'consumerReady'))
+          .then(this.waitAndPush.bind(this, event));
+      default:
+        return this._produce(event);
     }
   }
 }
 
 module.exports = {
-  STREAM_STATUS,
-  InternalStream
+  InternalStream,
+  strFromEvent
 };

--- a/src/subscribe.js
+++ b/src/subscribe.js
@@ -1,0 +1,31 @@
+// @flow
+const { transduce } = require('./basics');
+
+import type { Event } from './event';
+import type { Stream } from './basics';
+
+type Subscriber<T> = (event: Event<T>) => Promise<void> | void;
+
+function subscribe<T>(subscriber: Subscriber<T>): (Stream<T>) => Promise<void> {
+  return transduce(
+    undefined,
+    (_, event) => {
+      const result = subscriber(event);
+      const done = event.done || (event.error && true);
+      if (result instanceof Promise) {
+        return result.then(() => ({
+          accumulation: undefined,
+          done
+        }));
+      }
+      return {
+        accumulation: undefined,
+        done
+      };
+    },
+    () => undefined);
+}
+
+module.exports = {
+  subscribe
+};

--- a/src/transform.js
+++ b/src/transform.js
@@ -1,0 +1,48 @@
+// @flow
+const { transduceToStream } = require('./basics');
+const { wrapInPromise } = require('./utils');
+
+import type { Event } from './event';
+import type { Push } from './internalStream';
+import type { Stream } from './basics';
+
+export type Transformer<ConsumedT, ProducedT, SeedT = void> = (event: Event<ConsumedT>, push: Push<ProducedT>, seed: ?SeedT) => ?SeedT | Promise<?SeedT>;
+
+function transform<ConsumedT, ProducedT, SeedT>(transformer: Transformer<ConsumedT, ProducedT, SeedT>, seed: ?SeedT): (Stream<ConsumedT>) => Stream<ProducedT> {
+  const reducerTransformer = (reducer) => {
+    const wrappedTransformer = wrapInPromise(transformer);
+    let currentSeed = seed;
+    return (accumulation, consumedEvent) => {
+      let result = { accumulation, done: false };
+      return wrappedTransformer(
+        consumedEvent,
+        (producedEvent) => {
+          if (result instanceof Promise) {
+            result = result
+              .then(({ accumulation }) => reducer(accumulation, producedEvent));
+            return false;
+          }
+          else {
+            result = reducer(result.accumulation, producedEvent);
+            if (result instanceof Promise) {
+              return false;
+            }
+            else {
+              return !result.done;
+            }
+          }
+        },
+        currentSeed)
+        .then((newSeed) => {
+          currentSeed = newSeed;
+          return result;
+        });
+    };
+  };
+
+  return transduceToStream(reducerTransformer);
+}
+
+module.exports = {
+  transform
+};

--- a/test/produce.test.js
+++ b/test/produce.test.js
@@ -52,7 +52,7 @@ test('Pauses the production if there is a slow consumer (second version)', (t) =
           observedCount++;
           t.true(observedCount <= producedCount);
           // Keep a maximum lag between the producer and observer
-          t.true(producedCount - observedCount < 20);
+          t.true(producedCount - observedCount <= 100);
           t.true(push(event));
         }
         else {

--- a/test/subscribe.test.js
+++ b/test/subscribe.test.js
@@ -8,8 +8,8 @@ test('Handles the backpressure', (t) => {
   let expectedValue = 1;
   const LIMIT = 100;
   let done = false;
-  return produce((push, next) => {
-    //console.log(`${value} ->`);
+  return produce((push) => {
+    // console.log(`${value} ->`);
     push({ value: value++ });
     if (value > LIMIT) {
       push({ done: true });
@@ -17,7 +17,37 @@ test('Handles the backpressure', (t) => {
   })
     .thru(subscribe((event) => {
       if (event.value) {
-        //console.log(`-> ${event.value}`);
+        // console.log(`-> ${event.value}`);
+        t.is(event.value, expectedValue);
+        ++expectedValue;
+        return delay(100);
+      }
+      else if (event.done) {
+        done = true;
+      }
+    }))
+    .then(() => t.true(done));
+});
+
+test('Handles the backpressure (2)', (t) => {
+  let value = 1;
+  let expectedValue = 1;
+  const LIMIT = 100;
+  let done = false;
+  return produce((push) => {
+    let stop = false;
+    while (!stop) {
+      // console.log(`${value} ->`);
+      stop = !push({ value: value++ });
+      if (value > LIMIT) {
+        push({ done: true });
+        return;
+      }
+    }
+  })
+    .thru(subscribe((event) => {
+      if (event.value) {
+        // console.log(`-> ${event.value}`);
         t.is(event.value, expectedValue);
         ++expectedValue;
         return delay(100);

--- a/test/throwError.test.js
+++ b/test/throwError.test.js
@@ -13,12 +13,7 @@ test('Throws the given error', (t) => {
 test('Throws the given error properly', (t) => {
   const errorMessage = 'huhuhuhuhuh';
   t.plan(1);
-  try {
-    return throwError(new Error(errorMessage))
-      .thru(drain())
-      .catch((e) => t.is(e.message, errorMessage));
-  }
-  catch (e) {
-    console.log(e);
-  }
+  return throwError(new Error(errorMessage))
+    .thru(drain())
+    .catch((e) => t.is(e.message, errorMessage));
 });


### PR DESCRIPTION
On cc7b1ec2de66b00708ddfed86578507f80d01b3c (`master` branch)
```
$ NODE_ENV=production node ./benchmark/mapReduce.benchmark.js
alpes (map and reduce) x 61.48 ops/sec ±7.87% (73 runs sampled)
alpes (transduce) x 128 ops/sec ±1.41% (81 runs sampled)
node streams x 107 ops/sec ±1.41% (79 runs sampled)
highland x 491 ops/sec ±1.58% (80 runs sampled)
most x 14,189 ops/sec ±3.12% (80 runs sampled)
$ NODE_ENV=production node ./benchmark/drain.benchmark.js
alpes x 100 ops/sec ±10.98% (67 runs sampled)
node streams x 228 ops/sec ±6.79% (70 runs sampled)
highland x 1,372 ops/sec ±20.16% (38 runs sampled)
most x 7,684 ops/sec ±12.05% (37 runs sampled)
```

On 51ebe17b2c11ac0e16a3332c2e660e5871f8f3f1

```
$ NODE_ENV=production node ./benchmark/mapReduce.benchmark.js
alpes (map and reduce) x 189 ops/sec ±0.81% (82 runs sampled)
alpes (transduce) x 531 ops/sec ±1.17% (80 runs sampled)
node streams x 112 ops/sec ±1.40% (82 runs sampled)
highland x 483 ops/sec ±0.92% (81 runs sampled)
most x 14,543 ops/sec ±2.46% (80 runs sampled)
$ NODE_ENV=production node ./benchmark/drain.benchmark.js
alpes x 578 ops/sec ±0.81% (81 runs sampled)
node streams x 278 ops/sec ±1.35% (81 runs sampled)
highland x 4,149 ops/sec ±5.67% (66 runs sampled)
most x 47,783 ops/sec ±0.58% (81 runs sampled)
```

Overall between **x3** and **x6** speedup.